### PR TITLE
Improve unprotected initialize / setter detectors

### DIFF
--- a/slither_pess/detectors/unprotected_initialize.py
+++ b/slither_pess/detectors/unprotected_initialize.py
@@ -48,14 +48,15 @@ class UnprotectedInitialize(AbstractDetector):
         """Main function"""
         res = []
         for contract in self.compilation_unit.contracts_derived:
-            for f in contract.functions_and_modifiers_declared:
-                x = self._is_initialize(f)
-                if x:
-                    is_safe = self._has_modifiers(f)
-                    is_safe2 = self._has_require(f)
-                    if not is_safe and not is_safe2:
-                        res.append(self.generate_result([
-                            "Function ",
-                            f, ' is an unprotected initializer.',
-                            '\n']))
+            if not contract.is_library:
+                for f in contract.functions_and_modifiers_declared:
+                    x = self._is_initialize(f)
+                    if x:
+                        is_safe = self._has_modifiers(f)
+                        is_safe2 = self._has_require(f)
+                        if not is_safe and not is_safe2:
+                            res.append(self.generate_result([
+                                "Function ",
+                                f, ' is an unprotected initializer.',
+                                '\n']))
         return res

--- a/slither_pess/detectors/unprotected_setter.py
+++ b/slither_pess/detectors/unprotected_setter.py
@@ -42,6 +42,11 @@ class UnprotectedSetter(AbstractDetector):
                 return True
         if fun.visibility in ['internal','private']:
             return True
+        for node in fun.nodes:
+            if "require" in str(node):
+                for variable in node.variables_read:
+                    if str(variable.type) == "address":
+                        return True
         return fun.is_protected()
 
     def _detect(self):

--- a/slither_pess/detectors/unprotected_setter.py
+++ b/slither_pess/detectors/unprotected_setter.py
@@ -47,13 +47,14 @@ class UnprotectedSetter(AbstractDetector):
     def _detect(self):
         res = []
         for contract in self.compilation_unit.contracts_derived:
-            for f in contract.functions:
-                if not self.has_access_control(f):
-                    x = self.is_setter(f)
-                    if (x!= None):
-                        res.append(self.generate_result([
-                            "Function", ' ',
-                            f, ' is a non-protected setter ',
-                            x, ' is written'
-                            '\n']))
+            if not contract.is_library:
+                for f in contract.functions:
+                    if not self.has_access_control(f):
+                        x = self.is_setter(f)
+                        if (x!= None):
+                            res.append(self.generate_result([
+                                "Function", ' ',
+                                f, ' is a non-protected setter ',
+                                x, ' is written'
+                                '\n']))
         return res


### PR DESCRIPTION
The logic shared by both detectors is inconsistently applied.

- [ ] access control via require / modifiers for public function
- [ ] don't enforce restriction for library contracts (no state)