### PR TITLE
fix: failing on immutable contract reference call 

### DIFF
--- a/slither_pess/detectors/nft_approve_warning.py
+++ b/slither_pess/detectors/nft_approve_warning.py
@@ -43,8 +43,11 @@ class NftApproveWarning(AbstractDetector):
         irList = []
         for node in nodes:
             for ir in node.irs:
-                if not hasattr(ir.function, 'solidity_signature'): continue
-                if (ir.function.solidity_signature in self._signatures):
+                if (
+                    hasattr(ir, 'function')
+                    and hasattr(ir.function, 'solidity_signature')
+                    and ir.function.solidity_signature in self._signatures
+                ):
                     is_from_sender = is_dependent(ir.arguments[0], SolidityVariableComposed("msg.sender"), node.function.contract)
                     # is_from_self = is_dependent(ir.arguments[0], SolidityVariable("this"), node.function.contract)
                     if (not is_from_sender): # and not is_from_self

--- a/tests/Immutable_address_test.sol
+++ b/tests/Immutable_address_test.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.19;
+
+interface IERC20 {
+    function transferFrom(address from, address to, uint256 amount) external returns (bool);
+}
+
+contract Test
+{
+    IERC20 immutable TOKEN = IERC20(address(0));
+    function test() internal {
+        TOKEN.transferFrom(address(this), address(0), 0);
+    }
+}
+


### PR DESCRIPTION
Hi!

That solidity code:
```solidity
// SPDX-License-Identifier: MIT

pragma solidity ^0.8.19;

interface IERC20 {
    function transferFrom(address from, address to, uint256 amount) external returns (bool);
}

contract Test
{
    IERC20 immutable TOKEN = IERC20(address(0));
    function test() internal {
        TOKEN.transferFrom(address(this), address(0), 0);
    }
}
```

would crash nft_approve_warning with next traceback:

```traceback
…
  File "/home/y/work/pessimistic/slitherin/slither_pess/detectors/nft_approve_warning.py", line 65, in _detect                                                                                 
    for d in self._detect_arbitrary_from(f):                                                                                                                                                   
  File "/home/y/work/pessimistic/slitherin/slither_pess/detectors/nft_approve_warning.py", line 38, in _detect_arbitrary_from                                                                  
    return self._arbitrary_from(f.nodes)                                                                                                                                                       
  File "/home/y/work/pessimistic/slitherin/slither_pess/detectors/nft_approve_warning.py", line 50, in _arbitrary_from                                                                         
    and hasattr(ir.function, 'solidity_signature')                                                                                                                                             
AttributeError: 'TypeConversion' object has no attribute 'function'
```

I made a very simple fix!