### PR TITLE
fixed `IndexError`

### DIFF
--- a/slitherin/detectors/falsy_only_eoa_modifier.py
+++ b/slitherin/detectors/falsy_only_eoa_modifier.py
@@ -33,8 +33,9 @@ class OnlyEOACheck(AbstractDetector):
                     if is_tx: 
                         varListTx.append(var)
                 for i in range(len(varListTx)):
-                    if(str(n).__contains__(f'{varListMsg[i]} == {varListTx[i]}') or str(n).__contains__(f'{varListTx[i]} == {varListMsg[i]}')):
-                        return "True"
+                    for j in range(len(varListMsg)):
+                        if(str(n).__contains__(f'{varListMsg[j]} == {varListTx[i]}') or str(n).__contains__(f'{varListTx[i]} == {varListMsg[j]}')):
+                            return "True"
         return "False"
 
     def _detect(self):

--- a/tests/falsy_only_eoa_modifier_test.sol
+++ b/tests/falsy_only_eoa_modifier_test.sol
@@ -2,15 +2,21 @@ pragma solidity ^0.8.0;
 
 contract falsy_only_eoa_modifier_test {
     uint256 toSet;
-    bool isProtected = true;
+    address owner = msg.sender;
 
     modifier onlyOwner() {
-        require(isProtected);
+        require(owner == msg.sender);
         _;
     }
 
-    function set_vulnurable(uint256 setter) public onlyOwner {
+    function set_vulnerable(uint256 setter) public onlyOwner {
         if(msg.sender == tx.origin){
+            toSet = setter;
+        }
+    }
+
+    function set_tx_origin(uint256 setter) public onlyOwner {
+        if(owner == tx.origin){
             toSet = setter;
         }
     }


### PR DESCRIPTION
`OnlyEOACheck` detector fails when `len(varListTx) > len(varListMsg)`.

```js
function set_tx_origin(uint256 setter) public onlyOwner {
    if(owner == tx.origin){
        toSet = setter;
    }
}
```