### PR TITLE
Add check that the function is not a constructor

### DIFF
--- a/slitherin/detectors/public_vs_external.py
+++ b/slitherin/detectors/public_vs_external.py
@@ -29,7 +29,7 @@ class PublicVsExternal(AbstractDetector):
                     used_functions.add(call.name)
 
         for f in contract.functions_and_modifiers_declared:
-            if f.visibility == "public" and f.name not in used_functions:
+            if f.visibility == "public" and f.name not in used_functions and not f.is_constructor:
                 res.append(f)
         return res
 

--- a/tests/public_vs_external_test.sol
+++ b/tests/public_vs_external_test.sol
@@ -36,3 +36,9 @@ contract MinimalTest2 {
         uint256 k = fucntion_public_negative3();
     }
 }
+
+contract ConstructorTest {
+    constructor() {
+
+    }
+}

--- a/tests/public_vs_external_test.sol
+++ b/tests/public_vs_external_test.sol
@@ -42,3 +42,9 @@ contract ConstructorTest {
 
     }
 }
+
+contract ConstructorTest2 {
+    constructor(uint256 a, uint8 b) {
+        
+    }
+}


### PR DESCRIPTION
Fixes the issue when `pess-public-vs-external` marked constructors as issues.