### PR TITLE
fix: object of type NoneType has no len() - PotentialArithmOverflow detector fail

### DIFF
--- a/slitherin/detectors/potential_arith_overflow.py
+++ b/slitherin/detectors/potential_arith_overflow.py
@@ -86,7 +86,7 @@ class PotentialArithmOverflow(AbstractDetector):
                         errors.extend(response_errors)
                     if has_problems:
                         final_results.append((node, str(irs[-1].lvalue._type), errors))
-                if len(irs) > 0 and isinstance(irs[-1], ops.Return) and len(fun.return_type) == 1 and str(fun.return_type[0]) in INT_TYPES: # @todo currently works only with single returns
+                if len(irs) > 0 and isinstance(irs[-1], ops.Return) and fun.return_type is not None and len(fun.return_type) == 1 and str(fun.return_type[0]) in INT_TYPES: # @todo currently works only with single returns
                     expected_bits_cut = str(fun.return_type[0]).removeprefix("uint").removeprefix("int")
                     expected_bits = int(256 if not expected_bits_cut else expected_bits_cut)
                     has_problems = False


### PR DESCRIPTION
_Note: Sorry for the mess, rebase somehow went wrong on my side in the [old PR](https://github.com/pessimistic-io/slitherin/pull/148)_

Small fix to get rid of detector failing completely for some contracts. This is annoying because single detector fail stops the execution of other detectors.

Example error:

```
ERROR:root:Slither detection failed: object of type 'NoneType' has no len()
Traceback (most recent call last):
  File "/home/user/Github/Local/forgAi/core/analyze.py", line 670, in run_analysis
    self.run_slither_scan()
  File "/home/user/Github/Local/forgAi/core/analyze.py", line 556, in run_slither_scan
    slither, results_detectors, counter = run_all_detectors(
  File "/home/user/Github/Local/forgAi/core/utils.py", line 58, in run_all_detectors
    detector_resultss = slither.run_detectors()
  File "/home/user/Github/Local/forgAi/venv/lib/python3.10/site-packages/slither/slither.py", line 241, in run_detectors
    results = [d.detect() for d in self._detectors]
  File "/home/user/Github/Local/forgAi/venv/lib/python3.10/site-packages/slither/slither.py", line 241, in <listcomp>
    results = [d.detect() for d in self._detectors]
  File "/home/user/Github/Local/forgAi/venv/lib/python3.10/site-packages/slither/detectors/abstract_detector.py", line 203, in detect
    for r in [output.data for output in self._detect()]:
  File "/home/user/Github/Local/forgAi/venv/lib/python3.10/site-packages/slitherin/detectors/potential_arith_overflow.py", line 110, in _detect
    vulnerable_expressions = self._find_vulnerable_expressions(f)
  File "/home/user/Github/Local/forgAi/venv/lib/python3.10/site-packages/slitherin/detectors/potential_arith_overflow.py", line 89, in _find_vulnerable_expressions
    if len(irs) > 0 and isinstance(irs[-1], ops.Return) and len(fun.return_type) == 1 and str(fun.return_type[0]) in INT_TYPES: # @todo currently works only with single returns
TypeError: object of type 'NoneType' has no len()
```


Example contract to test with (without the patch): [0x61d25e9c65fb3bd2aa54e426b3044020dd339b8d](https://etherscan.io/address/0x61d25e9c65fb3bd2aa54e426b3044020dd339b8d#code)