### PR TITLE
added oz-access-managed modifier

### DIFF
--- a/slitherin/detectors/unprotected_setter.py
+++ b/slitherin/detectors/unprotected_setter.py
@@ -41,7 +41,11 @@ class UnprotectedSetter(AbstractDetector):
 
     def has_access_control(self, fun):
         for m in fun.modifiers:
-            if m.name in ["initializer", "onlyOwner"] or m.name.startswith("only"):
+            if m.name in [
+                "initializer",
+                "onlyOwner",
+                "restricted",
+            ] or m.name.startswith("only"):
                 return True
         if fun.visibility in ["internal", "private"]:
             return True


### PR DESCRIPTION
Went through oz acces control contracts, to identify all modifiers, used for role-protection. It seems like, only [restricted](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/c3f8b760ad9d0431f33e8303658ccbdcc1610f24/contracts/access/manager/AccessManaged.sol#L56-L59) from OZ AccessManaged was left. We support all others, because of the `only` prefix